### PR TITLE
fix: fyne warning

### DIFF
--- a/internal/screens/downloadCard.go
+++ b/internal/screens/downloadCard.go
@@ -34,15 +34,18 @@ func (i *index) downloadForm() *widget.Form {
 				i.showError(fmt.Errorf("please enter a hash"))
 				return
 			}
+			hashText := hash.Text
 			go func() {
-				i.showProgressWithMessage(fmt.Sprintf("Downloading %s", shortenHashOrAddress(hash.Text)))
+				i.showProgressWithMessage(fmt.Sprintf("Downloading %s", shortenHashOrAddress(hashText)))
 				ref, fileName, err := i.bl.GetBzz(context.Background(), dlAddr, nil, nil, nil)
 				if err != nil {
 					i.hideProgress()
 					i.showError(err)
 					return
 				}
-				hash.SetText("")
+				fyne.Do(func() {
+					hash.SetText("")
+				})
 				data, err := io.ReadAll(ref)
 				if err != nil {
 					i.hideProgress()
@@ -50,23 +53,25 @@ func (i *index) downloadForm() *widget.Form {
 					return
 				}
 				i.hideProgress()
-				saveFile := dialog.NewFileSave(func(writer fyne.URIWriteCloser, err error) {
-					if err != nil {
-						i.showError(err)
-						return
-					}
-					if writer == nil {
-						return
-					}
-					_, err = writer.Write(data)
-					if err != nil {
-						i.showError(err)
-						return
-					}
-					writer.Close()
-				}, i.Window)
-				saveFile.SetFileName(fileName)
-				saveFile.Show()
+				fyne.Do(func() {
+					saveFile := dialog.NewFileSave(func(writer fyne.URIWriteCloser, err error) {
+						if err != nil {
+							i.showError(err)
+							return
+						}
+						if writer == nil {
+							return
+						}
+						_, err = writer.Write(data)
+						if err != nil {
+							i.showError(err)
+							return
+						}
+						writer.Close()
+					}, i.Window)
+					saveFile.SetFileName(fileName)
+					saveFile.Show()
+				})
 			}()
 		},
 	}

--- a/internal/screens/infoCard.go
+++ b/internal/screens/infoCard.go
@@ -35,7 +35,9 @@ func (i *index) showInfoCard(ultraLightMode bool) *widget.Card {
 		for {
 			time.Sleep(time.Second * 5)
 			if i.bl != nil {
-				infoCard.SetSubTitle(fmt.Sprintf("Connected with %d peers", i.bl.ConnectedPeerCount()))
+				fyne.Do(func() {
+					infoCard.SetSubTitle(fmt.Sprintf("Connected with %d peers", i.bl.ConnectedPeerCount()))
+				})
 			}
 		}
 	}()

--- a/internal/screens/utils.go
+++ b/internal/screens/utils.go
@@ -72,21 +72,29 @@ func (i *index) printAppInfo() {
 }
 
 func (i *index) showProgressWithMessage(message string) {
-	i.progress = dialog.NewCustomWithoutButtons(message, widget.NewProgressBarInfinite(), i)
-	i.progress.Show()
+	fyne.Do(func() {
+		i.progress = dialog.NewCustomWithoutButtons(message, widget.NewProgressBarInfinite(), i)
+		i.progress.Show()
+	})
 }
 
 func (i *index) hideProgress() {
-	i.progress.Hide()
+	fyne.Do(func() {
+		if i.progress != nil {
+			i.progress.Hide()
+		}
+	})
 }
 
 func (i *index) showError(err error) {
-	label := widget.NewLabel(err.Error())
-	label.Wrapping = fyne.TextWrapWord
-	d := dialog.NewCustom("Error", "       Close       ", label, i.Window)
-	parentSize := i.Window.Canvas().Size()
-	d.Resize(fyne.NewSize(parentSize.Width*90/100, 0))
-	d.Show()
+	fyne.Do(func() {
+		label := widget.NewLabel(err.Error())
+		label.Wrapping = fyne.TextWrapWord
+		d := dialog.NewCustom("Error", "       Close       ", label, i.Window)
+		parentSize := i.Window.Canvas().Size()
+		d.Resize(fyne.NewSize(parentSize.Width*90/100, 0))
+		d.Show()
+	})
 }
 
 func (i *index) copyButton(s string) *widget.Button {
@@ -96,14 +104,16 @@ func (i *index) copyButton(s string) *widget.Button {
 }
 
 func (i *index) showErrorWithAddr(addr common.Address, err error) {
-	header := container.NewHBox(widget.NewLabel(shortenHashOrAddress(addr.String())), i.copyButton(addr.String()))
-	label := widget.NewLabel(err.Error())
-	label.Wrapping = fyne.TextWrapWord
-	content := container.NewBorder(header, label, nil, nil)
-	d := dialog.NewCustom("Error", "       Close       ", content, i.Window)
-	parentSize := i.Window.Canvas().Size()
-	d.Resize(fyne.NewSize(parentSize.Width*90/100, 0))
-	d.Show()
+	fyne.Do(func() {
+		header := container.NewHBox(widget.NewLabel(shortenHashOrAddress(addr.String())), i.copyButton(addr.String()))
+		label := widget.NewLabel(err.Error())
+		label.Wrapping = fyne.TextWrapWord
+		content := container.NewBorder(header, label, nil, nil)
+		d := dialog.NewCustom("Error", "       Close       ", content, i.Window)
+		parentSize := i.Window.Canvas().Size()
+		d.Resize(fyne.NewSize(parentSize.Width*90/100, 0))
+		d.Show()
+	})
 }
 
 func shortenHashOrAddress(item string) string {


### PR DESCRIPTION
Fixes for: 
"Error in Fyne call thread, this should have been called in fyne.Do[AndWait] ... "

Because the logs were full of it.